### PR TITLE
De-duplicate resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,25 +21,6 @@ resource "aws_subnet" "vpn_subnet" {
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_idn = "${aws_vpc.main.id}"
-
-  tags {
-    Name = "Internet Gateway for openvpn"
-  }
-}
-
-resource "aws_eip" "openvpn_eip" {
-  vpc        = true
-  depends_on = ["aws_internet_gateway.gw"]
-}
-
-resource "aws_route" "internet_access_openvpn" {
-  route_table_id         = "${aws_vpc.main.main_route_table_id}"
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.gw.id}"
-}
-
-resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.main.id}"
 
   tags {


### PR DESCRIPTION
And naturally, I somehow had added duplicates of three resources, the gateway, eip, and aws_route.  This patch addresses it.  Sorry!